### PR TITLE
Implement preset catalogue enumeration and MIDI learn mode

### DIFF
--- a/core/midi_handler.py
+++ b/core/midi_handler.py
@@ -23,6 +23,7 @@ class MidiSignals(QObject):
     pad_toggled = pyqtSignal(int)        # pad_index (0-based)
     knob_moved = pyqtSignal(int, int)    # pad_index (0-based), value 0-127
     fader_moved = pyqtSignal(int)        # value 0-127
+    learn_captured = pyqtSignal(int, int, int)  # msg_type (0x90/0xB0), channel, byte1
 
 
 class MidiHandler:
@@ -31,6 +32,7 @@ class MidiHandler:
         self.signals = MidiSignals()
         self._midi_in = rtmidi.MidiIn()
         self._running = False
+        self._learn_mode = False
 
     def start(self):
         """Open the first available MIDI port and start listening."""
@@ -49,6 +51,14 @@ class MidiHandler:
             self._midi_in.close_port()
             self._running = False
 
+    def set_learn_mode(self, active: bool):
+        """Enable or disable MIDI learn mode.
+
+        While active, the next Note-on or CC message is captured and emitted
+        via signals.learn_captured instead of being processed normally.
+        """
+        self._learn_mode = active
+
     def reload_map(self):
         """Call after saving new MIDI mappings in SettingsDialog."""
         # Callback reads from config.midi_map on every message — no restart needed.
@@ -66,6 +76,12 @@ class MidiHandler:
         status, byte1, byte2 = message[0], message[1], message[2]
         msg_type = status & 0xF0
         channel = status & 0x0F
+
+        # Learn mode: capture the next Note-on or CC and hand it to the dialog
+        if self._learn_mode and msg_type in (0x90, 0xB0) and byte2 > 0:
+            self._learn_mode = False
+            self.signals.learn_captured.emit(msg_type, channel, byte1)
+            return
 
         midi_map = self._config.midi_map
 

--- a/core/synth_engine.py
+++ b/core/synth_engine.py
@@ -17,6 +17,7 @@ The synth is created with the JACK audio driver so pw-jack routes it through
 PipeWire automatically.
 """
 
+import ctypes
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -65,34 +66,50 @@ class SynthEngine:
 
     def _build_catalogue(self):
         """
-        Enumerate every bank/program across all loaded soundfonts.
+        Enumerate every preset that actually exists in each loaded soundfont
+        using FluidSynth's sfont iteration API via ctypes.
+
         Each entry: {soundfont_path, soundfont_name, bank, program, label, gm_family}
-        Sorted by GM family (program // 8) then label.
+        Sorted by GM family (bank-0 program // 8) then label.
         """
         self._catalogue = []
+
+        # pyFluidSynth exposes the underlying ctypes CDLL as fluidsynth.lib
+        _lib = fluidsynth.lib
+        _lib.fluid_synth_get_sfont_by_id.restype = ctypes.c_void_p
+        _lib.fluid_sfont_iteration_next.restype = ctypes.c_void_p
+        _lib.fluid_preset_get_name.restype = ctypes.c_char_p
+        _lib.fluid_preset_get_banknum.restype = ctypes.c_int
+        _lib.fluid_preset_get_num.restype = ctypes.c_int
+
         for sf_path, sfid in self._sf_ids.items():
             sf_name = Path(sf_path).stem
-            # FluidSynth exposes sfont presets via iteration
-            preset = self._fs.sfont_select(0, sfid)  # select temporarily
-            for bank in range(128):
-                for prog in range(128):
-                    name = self._fs.channel_info(0)  # placeholder — see note
-                    # TODO: use fluidsynth.Synth.sfont_get_preset_name when
-                    # available in the installed pyFluidSynth version, or
-                    # fall back to General MIDI program name lookup table.
-                    gm_name = GM_PROGRAM_NAMES.get(prog, f"Program {prog}")
-                    self._catalogue.append({
-                        "soundfont_path": sf_path,
-                        "soundfont_name": sf_name,
-                        "bank": bank,
-                        "program": prog,
-                        "label": gm_name,
-                        "gm_family": prog // 8,
-                    })
-            break  # placeholder — full implementation iterates properly
+            sfont_ptr = _lib.fluid_synth_get_sfont_by_id(self._fs.synth, ctypes.c_uint(sfid))
+            if not sfont_ptr:
+                continue
 
-        # Real implementation: use fluid_sfont_iteration_start / next
-        # to walk only the presets that actually exist in each soundfont.
+            _lib.fluid_sfont_iteration_start(ctypes.c_void_p(sfont_ptr))
+            while True:
+                preset_ptr = _lib.fluid_sfont_iteration_next(ctypes.c_void_p(sfont_ptr))
+                if not preset_ptr:
+                    break
+
+                bank = _lib.fluid_preset_get_banknum(ctypes.c_void_p(preset_ptr))
+                prog = _lib.fluid_preset_get_num(ctypes.c_void_p(preset_ptr))
+                raw_name = _lib.fluid_preset_get_name(ctypes.c_void_p(preset_ptr))
+                name = (raw_name.decode("utf-8", errors="replace")
+                        if raw_name else GM_PROGRAM_NAMES.get(prog, f"Program {prog}"))
+
+                self._catalogue.append({
+                    "soundfont_path": sf_path,
+                    "soundfont_name": sf_name,
+                    "bank": bank,
+                    "program": prog,
+                    "label": name,
+                    "gm_family": prog // 8 if bank == 0 else 0,
+                })
+
+        self._catalogue.sort(key=lambda e: (e["gm_family"], e["label"]))
 
     @property
     def catalogue(self) -> list[dict]:

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -12,6 +12,7 @@ Saves to ~/.config/soundpad/midi_map.json on "OK".
 Calls midi_handler.reload_map() so changes take effect without restarting.
 """
 
+from typing import Optional
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
     QTableWidget, QTableWidgetItem, QHeaderView, QDialogButtonBox
@@ -31,6 +32,8 @@ class SettingsDialog(QDialog):
 
         self.setWindowTitle("MIDI Settings")
         self.setMinimumWidth(460)
+        self._active_learn_btn: Optional[QPushButton] = None
+        self._midi.signals.learn_captured.connect(self._on_learn_captured)
         self._build_ui()
 
     def _build_ui(self):
@@ -49,13 +52,11 @@ class SettingsDialog(QDialog):
         layout.addWidget(QLabel("<b>Master Fader CC</b>"))
         fader_row = QHBoxLayout()
         fader = self._working_map["master_fader"]
-        self._fader_ch = QTableWidgetItem(str(fader["channel"] + 1))
-        self._fader_cc = QTableWidgetItem(str(fader["cc"]))
-        fader_label = QLabel(f"Channel: {fader['channel'] + 1}   CC: {fader['cc']}")
-        fader_label.setStyleSheet("color: #a0a0c0;")
-        fader_row.addWidget(fader_label)
+        self._fader_label = QLabel(f"Channel: {fader['channel'] + 1}   CC: {fader['cc']}")
+        self._fader_label.setStyleSheet("color: #a0a0c0;")
+        fader_row.addWidget(self._fader_label)
         learn_fader = QPushButton("Learn")
-        learn_fader.clicked.connect(lambda: self._start_learn("fader", 0))
+        learn_fader.clicked.connect(lambda checked=False, b=learn_fader: self._start_learn("fader", 0, b))
         fader_row.addWidget(learn_fader)
         layout.addLayout(fader_row)
 
@@ -77,27 +78,63 @@ class SettingsDialog(QDialog):
         return table
 
     def _populate_pad_table(self):
+        self._active_learn_btn = None  # stale after table rebuild
         for i, entry in enumerate(self._working_map["pads"]):
             self._pad_table.setItem(i, 0, QTableWidgetItem(f"Pad {entry['pad']}"))
             self._pad_table.setItem(i, 1, QTableWidgetItem(str(entry["channel"] + 1)))
             self._pad_table.setItem(i, 2, QTableWidgetItem(str(entry["note"])))
             btn = QPushButton("Learn")
-            btn.clicked.connect(lambda checked, idx=i: self._start_learn("pad", idx))
+            btn.clicked.connect(lambda checked, idx=i, b=btn: self._start_learn("pad", idx, b))
             self._pad_table.setCellWidget(i, 3, btn)
 
     def _populate_knob_table(self):
+        self._active_learn_btn = None  # stale after table rebuild
         for i, entry in enumerate(self._working_map["knobs"]):
             self._knob_table.setItem(i, 0, QTableWidgetItem(f"Pad {entry['pad']}"))
             self._knob_table.setItem(i, 1, QTableWidgetItem(str(entry["channel"] + 1)))
             self._knob_table.setItem(i, 2, QTableWidgetItem(str(entry["cc"])))
             btn = QPushButton("Learn")
-            btn.clicked.connect(lambda checked, idx=i: self._start_learn("knob", idx))
+            btn.clicked.connect(lambda checked, idx=i, b=btn: self._start_learn("knob", idx, b))
             self._knob_table.setCellWidget(i, 3, btn)
 
-    def _start_learn(self, target_type: str, index: int):
-        """Temporarily redirect MIDI input to capture the next message."""
+    def _start_learn(self, target_type: str, index: int, btn: QPushButton):
+        """Activate MIDI learn: next Note-on or CC updates the target row."""
+        # Cancel any previous pending learn
+        if self._active_learn_btn is not None:
+            self._active_learn_btn.setText("Learn")
+            self._active_learn_btn.setEnabled(True)
+
         self._learning_target = (target_type, index)
-        # TODO: hook into MidiHandler's learn mode and update table on capture
+        self._active_learn_btn = btn
+        btn.setText("Waiting…")
+        btn.setEnabled(False)
+        self._midi.set_learn_mode(True)
+
+    def _on_learn_captured(self, msg_type: int, channel: int, byte1: int):
+        """Receive the captured MIDI message and update the mapping."""
+        if self._active_learn_btn is not None:
+            self._active_learn_btn.setText("Learn")
+            self._active_learn_btn.setEnabled(True)
+            self._active_learn_btn = None
+
+        if self._learning_target is None:
+            return
+
+        target_type, index = self._learning_target
+        self._learning_target = None
+
+        if target_type == "pad" and msg_type == 0x90:
+            self._working_map["pads"][index]["channel"] = channel
+            self._working_map["pads"][index]["note"] = byte1
+            self._populate_pad_table()
+        elif target_type == "knob" and msg_type == 0xB0:
+            self._working_map["knobs"][index]["channel"] = channel
+            self._working_map["knobs"][index]["cc"] = byte1
+            self._populate_knob_table()
+        elif target_type == "fader" and msg_type == 0xB0:
+            self._working_map["master_fader"]["channel"] = channel
+            self._working_map["master_fader"]["cc"] = byte1
+            self._fader_label.setText(f"Channel: {channel + 1}   CC: {byte1}")
 
     def _reset_defaults(self):
         from core.config import DEFAULT_MIDI_MAP


### PR DESCRIPTION
## Summary

- **Preset catalogue** (`core/synth_engine.py`): replaced the placeholder `_build_catalogue` (which blindly iterated 128×128 bank/program slots) with proper FluidSynth sfont iteration via ctypes (`fluid_sfont_iteration_start` / `fluid_sfont_iteration_next`). Only presets that actually exist in each soundfont are enumerated; real preset names come from `fluid_preset_get_name`.
- **MIDI learn** (`core/midi_handler.py`): added `learn_captured` signal and `set_learn_mode()`; when active, the next Note-on or CC message is captured and re-emitted instead of being routed normally.
- **Settings dialog** (`ui/settings_dialog.py`): implemented `_start_learn` / `_on_learn_captured`; clicking Learn changes the button to "Waiting…", the next physical control press fills in the channel/note/CC value and restores the button.

## Test plan

- [ ] App launches via `pw-jack python3 soundpad.py` with no errors
- [ ] Preset browser populates with real instrument names from soundfonts in `/usr/share/sounds/sf2/`
- [ ] Selecting a preset assigns it to the pad and returns to main view
- [ ] Settings: click Learn on a pad row, press a pad on the Launchkey, channel/note updates
- [ ] Settings: click Learn on a knob row, turn a knob, channel/CC updates
- [ ] Settings: Learn on fader, move fader, CC updates
- [ ] OK saves midi_map.json; remapped controls work immediately without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)